### PR TITLE
update removeNode to use single update call for children updates, update tests

### DIFF
--- a/bot/src/services/database/databaseService.ts
+++ b/bot/src/services/database/databaseService.ts
@@ -61,11 +61,19 @@ export class DatabaseService implements IDatabaseService {
       const operations = [];
 
       // re-parent all children to parent of node being removed
-      for (const child of children) {
+      operations.push(
+        this.prismaClient.node.updateMany({
+          where: { parentId: userId },
+          data: { parentId: parent.userId },
+        })
+      );
+
+      // check if user is the root of the tree (a founder), if so update old group to that of the new parent
+      if (user.group === user.name) {
         operations.push(
-          this.prismaClient.node.update({
-            where: { userId: child.userId },
-            data: { parentId: parent.userId },
+          this.prismaClient.node.updateMany({
+            where: { group: user.group },
+            data: { group: parent.group, color: parent.color },
           })
         );
       }


### PR DESCRIPTION
# Description

Updates removeNode logic to use a single `updateMany` command instead of multiple `update` commands when updating children nodes in the tree. Additionally, adds logic to update a 'tree' of users if its root node leaves, so the whole subtree gets absorbed into the adjacent tree.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Unit Tests
- [X] Mutation Testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

